### PR TITLE
Adds default config for Access Point setup

### DIFF
--- a/files/etc/config/dhcp
+++ b/files/etc/config/dhcp
@@ -1,0 +1,24 @@
+config 'dnsmasq'
+    option domainneeded  1
+    option boguspriv   1
+    option filterwin2k   0
+    option localise_queries  1
+    option rebind_protection 1
+    option rebind_localhost  0
+    option local           '/lan/'
+    option domain          'lan'
+    option expandhosts   1
+    option nonegcache  0
+    option authoritative   1
+    option readethers        1
+    option leasefile   '/tmp/dhcp.leases'
+    option resolvfile  '/tmp/resolv.conf.auto'
+
+config 'dhcp' 'lan'
+    option 'interface'   'lan'
+    option 'start'       '100'
+    option 'limit'       '150'
+    option 'leasetime'   '12h'
+    option 'networkid'   'wlan0'
+    option ra server
+    option dhcpv6 server

--- a/files/etc/config/firewall
+++ b/files/etc/config/firewall
@@ -8,6 +8,7 @@ config zone
     option name     lan
     list   network      'ethernet'
     list   network      'wifi'
+    list   network      'lan'
     option input        ACCEPT
     option output       ACCEPT
     option forward      ACCEPT

--- a/files/etc/config/network
+++ b/files/etc/config/network
@@ -11,5 +11,11 @@ config interface 'ethernet'
     option ifname 'eth0'
     option proto 'dhcp'
 
+config interface 'lan'
+    option ifname 'wlan0'
+    option proto 'static'
+    option ipaddr '192.168.1.101'
+    option netmask '255.255.255.0'
+
 config switch 'mt7620'
     option enable_vlan 0

--- a/files/etc/config/wireless
+++ b/files/etc/config/wireless
@@ -10,4 +10,9 @@ config wifi-iface
 	option device 'radio0'
 	option network 'wifi'
 	option mode 'sta'
+
+config wifi-iface
+	option device 'radio0'
+	option network 'lan'
+	option mode 'ap'
 	option encryption 'psk2'


### PR DESCRIPTION
In tandem with [this PR](https://github.com/tessel/t2-cli/pull/405), this is the default config needed to enable an access point using the `ap` command from t2-cli. This does not include IP forwarding, which would allow Tessel to act as a router as well. 

Reference Material:
- [DNS/DHCP Configuration](http://wiki.openwrt.org/doc/uci/dhcp?s[]=interface&s[]=wlan0)
- [Using your Raspberry Pi as a Wireless Router and Web Server](http://www.daveconroy.com/using-your-raspberry-pi-as-a-wireless-router-and-web-server/)

Very open to feedback since this is yet untested (until I get home and flash my Tessel), and I'm very new to OpenWRT/networking concepts. 

**Update - 30/10/2015:**
After setting up this configuration on my Tessel, then running `/etc/init.d/dnsmasq start` and `/etc/init.d/odhcpd restart`, my computer was able to connect to the broadcasted and ping the IP address. The one caveat I'm still investigating is the need for Tessel to be connected to a wifi network as well. Not sure if this could be resolved by using a different network ID / ifname. 