### PR TITLE
Explicitly set initial wireless settings to disabled

### DIFF
--- a/files/etc/config/wireless
+++ b/files/etc/config/wireless
@@ -4,15 +4,17 @@ config wifi-device 'radio0'
 	option hwmode '11g'
 	option path '10180000.wmac'
 	option htmode 'HT20'
-	option disabled 1
+	option disabled '0'
 
 config wifi-iface
 	option device 'radio0'
 	option network 'wifi'
 	option mode 'sta'
+	option disabled '1'
 
 config wifi-iface
 	option device 'radio0'
 	option network 'lan'
 	option mode 'ap'
 	option encryption 'psk2'
+	option disabled '1'


### PR DESCRIPTION
I've been having issues when the `ap` config, even if it hasn't been set up yet, blocks a successfully station mode attempt. I believe what happens is that the lack of a `disabled` property means the acess point is enabled by default however because it doesn't have all the required keys (ssid, etc.), the wireless configuration as a whole is treated as invalid.

~~I still need to test this.~~ See smoke tests described within #43 which I tested on two different T2s.