### PR TITLE
Add madplay, remove sox and lame, which are unnecesary for basic playback

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -50,13 +50,11 @@ PACKAGES += ca-certificates
 PACKAGES += kmod-usb-audio
 PACKAGES += kmod-sound-core
 PACKAGES += kmod-sound-i8x0
-PACKAGES += portaudio
 PACKAGES += alsa-lib
 PACKAGES += alsa-utils
 PACKAGES += libbz2
 PACKAGES += ffmpeg
-PACKAGES += lame
-PACKAGES += sox
+PACKAGES += madplay
 
 # JavaScript
 PACKAGES += node


### PR DESCRIPTION
This is necessary for [tessel-av](https://github.com/tessel/tessel-av/blob/master/lib/speaker.js#L100)