### PR TITLE
Ubuntu Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ make -j50
 The resulting sysupgrade image is
 `openwrt/bin/ramips/openwrt-ramips-mt7620-tessel-squashfs-sysupgrade.bin`.
 
+### Dependencies
+If you get an error like this (Ubuntu):
+
+```
+Build dependency: Please install ncurses. (Missing libncurses.so or ncurses.h)
+```
+you are required to install some source dependencies:
+```
+sudo apt-get install zlib1g-dev libncurses5-dev
+```
+
 ### Related OpenWrt documentation
 
 * [Creating packages](http://wiki.openwrt.org/doc/devel/packages)


### PR DESCRIPTION
Ubuntu requires `zlib1g-dev` `libncurses5-dev` which is not clear from
native error reporting. For that reason this information will save some
peoples time