### PR TITLE
Update Node to 6.1.0

### DIFF
--- a/package/node/node/Makefile
+++ b/package/node/node/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v4.4.3
+PKG_VERSION:=v6.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=node-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nodejs.org/dist/${PKG_VERSION}/
-PKG_SHA256SUM:=8e67b95721aab7bd721179da2fe5dd97f9acc1306c15c9712ee103bcd6381638
+PKG_SHA256SUM:=9e67ef0b8611e16e6e311eccf0489a50fe76ceebeea3023ef4f51be647ae4bc3
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=
@@ -66,4 +66,3 @@ endef
 
 $(eval $(call BuildPackage,node))
 $(eval $(call BuildPackage,npm))
-


### PR DESCRIPTION
I tested blinky and the ambient module and they worked for me. You can grab the image [here](https://s3.amazonaws.com/builds.tessel.io/custom/openwrt-ramips-mt7620-tessel-squashfs-sysupgrade-node-6.1.0.bin). You will need to be on the latest master of t2-cli since tessel/t2-cli#698 was landed after `0.0.19` was released and there hasn't been another release yet.

You can update your Tessel with: `t2 update --openwrt-path PATH_TO_DOWNLOAD`

---

This updates the OpenWRT submodule to include this commit: https://github.com/tessel/openwrt/commit/4647609084786c1e11808d4e22b1ca29b4913b78

There is more information on that commit, but it comes down to patching uClibc to support the `nearbyintf` function needed by Node 6.x.

---

**Note**: I'd like to cut the next firmware release where this is included. I'd love for someone to walk me through it on Slack. 😄  
